### PR TITLE
[Enhancement] Add Generation to meow lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.DS_Store
+*.log
+build/

--- a/bin/meow.js
+++ b/bin/meow.js
@@ -77,10 +77,11 @@ getopts(options).then(function(opts) {
                             console.log('Kitty #' + kitty.id);
                             indented({
                                 "Birthdate":   formatDate(kitty.birthTime),
+                                "Owner":       kitty.owner,
+                                "Generation":  kitty.generation,
                                 "Busy Until":  kitty.nextActionAt,
                                 "Genes":       kitty.genes,
                                 "Matron Id":   String(kitty.matronId),
-                                "Owner":       kitty.owner,
                                 "Sire Id":     String(kitty.sireId),
                                 "Siring With": kitty.siringWithId,
                                 "URL":         ('https://www.cryptokitties.co/kitty/' + kittyId)

--- a/bin/meow.js
+++ b/bin/meow.js
@@ -80,8 +80,8 @@ getopts(options).then(function(opts) {
                                 "Busy Until":  kitty.nextActionAt,
                                 "Generation":  kitty.generation,
                                 "Genes":       kitty.genes,
-                                "Owner":       kitty.owner,
                                 "Matron Id":   String(kitty.matronId),
+                                "Owner":       kitty.owner,
                                 "Sire Id":     String(kitty.sireId),
                                 "Siring With": kitty.siringWithId,
                                 "URL":         ('https://www.cryptokitties.co/kitty/' + kittyId)

--- a/bin/meow.js
+++ b/bin/meow.js
@@ -77,10 +77,10 @@ getopts(options).then(function(opts) {
                             console.log('Kitty #' + kitty.id);
                             indented({
                                 "Birthdate":   formatDate(kitty.birthTime),
-                                "Owner":       kitty.owner,
-                                "Generation":  kitty.generation,
                                 "Busy Until":  kitty.nextActionAt,
+                                "Generation":  kitty.generation,
                                 "Genes":       kitty.genes,
+                                "Owner":       kitty.owner,
                                 "Matron Id":   String(kitty.matronId),
                                 "Sire Id":     String(kitty.sireId),
                                 "Siring With": kitty.siringWithId,

--- a/index.js
+++ b/index.js
@@ -57,21 +57,20 @@ var cooldownNames = [
 
 function Kitty(kittyId, details) {
     ethers.utils.defineProperty(this, 'id', kittyId);
-
     ethers.utils.defineProperty(this, 'matronId', details.matronId.toNumber());
     ethers.utils.defineProperty(this, 'sireId', details.sireId.toNumber());
-    ethers.utils.defineProperty(this, 'generation', details.generation.toNumber());
 
     ethers.utils.defineProperty(this, 'birthTime', details.birthTime.toNumber());
-    ethers.utils.defineProperty(this, 'nextActionAt', details.nextActionAt.toNumber());
-    ethers.utils.defineProperty(this, 'siringWithId', details.siringWithId.toNumber());
-
-    ethers.utils.defineProperty(this, 'cooldownIndex', details.cooldownIndex.toNumber());
+    ethers.utils.defineProperty(this, 'generation', details.generation.toNumber());
 
     ethers.utils.defineProperty(this, 'genes', details.genes.toHexString());
 
+    ethers.utils.defineProperty(this, 'cooldownIndex', details.cooldownIndex.toNumber());
+    ethers.utils.defineProperty(this, 'nextActionAt', details.nextActionAt.toNumber());
+
     ethers.utils.defineProperty(this, 'ready', details.isReady);
     ethers.utils.defineProperty(this, 'pregnant', details.isGestating);
+    ethers.utils.defineProperty(this, 'siringWithId', details.siringWithId.toNumber());
 
     ethers.utils.defineProperty(this, 'owner', details.owner);
 }


### PR DESCRIPTION
## Description
This PR adds the generation information to the command `meow lookup`

## Changes
- adds a `.gitignore`
- organizes imports of core props for `index.js`
- adds  `Generation` to `meow lookup`

## Example
```
$ meow loookup 10628
Kitty #10628
  Birthdate:    2017-12-01 23:17:05
  Owner:        0x88b8601E1679AbDe44332F0e3eFF32396fcDaA2D
  Generation:   5
  Busy Until:   4679125
  Genes:        0x5a12b318851a46e421ee18000310c67396e08146218e7318e343dcf639ae
  Matron Id:    10342
  Sire Id:      10258
  Siring With:  0
  URL:          https://www.cryptokitties.co/kitty/10628
```

## Tests
- [x] verified `meow lookup` returns expected output